### PR TITLE
Integrate with blackjack-strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Blackjack tools",
   "main": "sim.js",
   "dependencies": {
-    "knuth-shuffle": "^1.0.1"
+    "knuth-shuffle": "^1.0.1",
+    "blackjack-strategy": "^1.1.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/sim.js
+++ b/sim.js
@@ -1,6 +1,5 @@
 'use strict';
 var blackjack = require('./blackjack');
-var strategy = require('./strategy');
 var game = require('./game');
 
 // setup


### PR DESCRIPTION
I've been working on a node module that provides Basic Strategy recommendations, and ran across your project which I used as a test client.  This change integrates in with the blackjack-strategy module, which will provide recommendations as you implement other blackjack options such as split.
